### PR TITLE
ci: enable nx release targets

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -32,6 +32,15 @@
       "cache": true,
       "dependsOn": ["^build"],
       "inputs": ["production", "^production"]
+    },
+    "release": {
+      "executor": "nx:run-commands",
+      "outputs": [],
+      "options": {
+        "command": "npx release-it --ci",
+        "cwd": "{projectRoot}"
+      },
+      "dependsOn": ["^release"]
     }
   },
   "namedInputs": {

--- a/packages/aws/cdk/constructs/project.json
+++ b/packages/aws/cdk/constructs/project.json
@@ -22,7 +22,8 @@
       "executor": "@nx/vite:test",
       "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {}
-    }
+    },
+    "release": {}
   },
   "tags": ["aws", "cdk"]
 }

--- a/packages/python/extraction/project.json
+++ b/packages/python/extraction/project.json
@@ -60,7 +60,8 @@
         "command": "poetry run pytest tests/",
         "cwd": "packages/python/extraction"
       }
-    }
+    },
+    "release": {}
   },
   "tags": []
 }


### PR DESCRIPTION
This PR enables Nx `release` targets for CDK constructs and the Python extraction helper library.