### PR TITLE
chore: add rollup to aws cdk constructs and fix github actions remote url

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: |
           git remote rm origin
-          git remote add origin https://vm-x-ai:${GITHUB_TOKEN}@github.com/vm-x-ai/vm-x-ai-sdk.git
+          git remote add origin https://vm-x-ai:${GITHUB_TOKEN}@github.com/vm-x-ai/vm-x-ai-labs.git
           git symbolic-ref HEAD refs/heads/main
           git config --global push.autoSetupRemote true
           git config user.name "vm-x-ai-release[bot]"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: |
           git remote rm origin
-          git remote add origin https://vm-x-ai:${GITHUB_TOKEN}@github.com/vm-x-ai/vm-x-ai-labs.git
+          git remote add origin https://vm-x-ai:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
           git symbolic-ref HEAD refs/heads/main
           git config --global push.autoSetupRemote true
           git config user.name "vm-x-ai-release[bot]"

--- a/packages/aws/cdk/constructs/package.json
+++ b/packages/aws/cdk/constructs/package.json
@@ -21,12 +21,10 @@
     "email": "eng@vm-x.ai"
   },
   "dependencies": {
-    "tslib": "^2.3.0",
     "aws-cdk-lib": "^2.143.0",
     "constructs": "^10.3.0",
     "tar": "^7.1.0"
   },
-  "type": "module",
   "main": "./src/index.js",
   "typings": "./src/index.d.ts"
 }

--- a/packages/aws/cdk/constructs/project.json
+++ b/packages/aws/cdk/constructs/project.json
@@ -5,13 +5,40 @@
   "projectType": "library",
   "targets": {
     "build": {
-      "executor": "@nx/js:tsc",
+      "executor": "@nx/rollup:rollup",
       "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
       "options": {
-        "outputPath": "dist/packages/aws/cdk/constructs",
         "main": "packages/aws/cdk/constructs/src/index.ts",
+        "outputPath": "dist/packages/aws/cdk/constructs",
         "tsConfig": "packages/aws/cdk/constructs/tsconfig.lib.json",
-        "assets": []
+        "compiler": "swc",
+        "project": "packages/aws/cdk/constructs/package.json",
+        "format": ["esm", "cjs"],
+        "external": "all",
+        "rollupConfig": "packages/aws/cdk/constructs/rollup.config.js",
+        "generateExportsField": true,
+        "assets": [
+          {
+            "glob": "packages/aws/cdk/constructs/README.md",
+            "input": ".",
+            "output": "."
+          },
+          {
+            "glob": "packages/aws/cdk/constructs/CHANGELOG.md",
+            "input": ".",
+            "output": "."
+          }
+        ]
+      },
+      "configurations": {
+        "production": {
+          "optimization": true,
+          "sourceMap": false,
+          "namedChunks": false,
+          "extractLicenses": true,
+          "vendorChunk": false
+        }
       }
     },
     "lint": {

--- a/packages/aws/cdk/constructs/rollup.config.js
+++ b/packages/aws/cdk/constructs/rollup.config.js
@@ -1,0 +1,4 @@
+module.exports = (config) => {
+  // config.output.preserveModules = true;
+  return config;
+};


### PR DESCRIPTION
This PR changes the AWS CDK Constructs library builder to use rollup to compile the library with both CJS and ESM and also fixes the GitHub actions to use the right git remote URL.